### PR TITLE
feat: implement AuthService for password hashing and JWT operations

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,0 +1,36 @@
+# Project State: my-new-app
+
+## Phase
+planning
+
+## Last Updated
+2026-02-28T16:30:00Z
+
+## Last Issue Processed
+#7 — Implement AuthService for password hashing and JWT operations
+
+## Decisions
+
+- Issue #7: `authService.js` uses named ES module exports; user objects strip `password_hash` via destructuring before returning to callers.
+
+## Constraints
+
+- Runtime: Node.js 20 (LTS) — no polyfills for natively available features.
+- Module system: ES Modules (`"type": "module"`) throughout; no CommonJS `require()`.
+- Database: PostgreSQL 15+ — use `gen_random_uuid()` (no `uuid-ossp` extension needed).
+- No ORM: All SQL is written explicitly; `pg` pool is the only database abstraction.
+- Authentication: Stateless JWT only; no server-side session store in MVP scope.
+- Password storage: `bcrypt` with configurable rounds (default 12).
+- Scope: REST API backend only; no frontend, no caching layer, no message broker in MVP.
+
+## Completed Issues
+
+- #7 — Implement AuthService for password hashing and JWT operations
+
+## Next Recommended Issue
+
+**Issue 0** — "Initialize project scaffold with package.json and directory structure"
+
+This is the foundational prerequisite for all other issues. Start here by creating
+`package.json`, `.env.example`, `.gitignore`, and the `src/` directory tree as described
+in `ISSUES.json` index 0.

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,0 +1,45 @@
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import config from '../config.js';
+import * as UserRepository from '../repositories/userRepository.js';
+
+export async function hashPassword(plaintext) {
+  return bcrypt.hash(plaintext, config.bcryptRounds);
+}
+
+export async function comparePassword(plaintext, hash) {
+  return bcrypt.compare(plaintext, hash);
+}
+
+export function generateToken(userId) {
+  return jwt.sign({ userId }, config.jwtSecret, { expiresIn: config.jwtTtlSeconds });
+}
+
+export function verifyToken(token) {
+  return jwt.verify(token, config.jwtSecret);
+}
+
+export async function register({ email, password }) {
+  const existing = await UserRepository.findByEmail(email);
+  if (existing) {
+    throw new Error('Email already registered');
+  }
+  const passwordHash = await hashPassword(password);
+  const user = await UserRepository.createUser({ email, passwordHash });
+  const { password_hash, ...userWithoutPassword } = user;
+  return userWithoutPassword;
+}
+
+export async function login({ email, password }) {
+  const user = await UserRepository.findByEmail(email);
+  if (!user) {
+    throw new Error('Invalid credentials');
+  }
+  const valid = await comparePassword(password, user.password_hash);
+  if (!valid) {
+    throw new Error('Invalid credentials');
+  }
+  const token = generateToken(user.id);
+  const { password_hash, ...userWithoutPassword } = user;
+  return { user: userWithoutPassword, token };
+}


### PR DESCRIPTION
## Summary

- Adds `src/services/authService.js` with six named exports: `hashPassword`, `comparePassword`, `generateToken`, `verifyToken`, `register`, and `login`
- Uses `bcrypt` for password hashing with rounds from `config.bcryptRounds`; `jsonwebtoken` for signing/verifying tokens using `config.jwtSecret` and `config.jwtTtlSeconds`
- `register` throws `Error('Email already registered')` on duplicate email; `login` throws `Error('Invalid credentials')` on bad credentials
- All returned user objects strip `password_hash` before being returned to callers

Closes #7

## Test plan

- [ ] `hashPassword` produces a bcrypt hash verifiable with `bcrypt.compare`
- [ ] `comparePassword` returns `true` for matching plaintext/hash and `false` otherwise
- [ ] `generateToken` returns a valid JWT signed with `jwtSecret` and expiring after `jwtTtlSeconds`
- [ ] `verifyToken` returns decoded payload for valid token; throws `JsonWebTokenError`/`TokenExpiredError` for invalid/expired tokens
- [ ] `register` creates a new user and returns the row without `password_hash`; throws on duplicate email
- [ ] `login` returns `{ user, token }` on success; throws on wrong password or unknown email

🤖 Generated with [Claude Code](https://claude.com/claude-code)