### PR TITLE
feat: add users table migration and migration runner

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,0 +1,28 @@
+# Project State: my-new-app
+
+## Phase
+planning
+
+## Last Updated
+2026-02-28T19:50:00Z
+
+## Last Issue Processed
+#4 — Write database migration for users table and migration runner
+
+## Decisions
+
+- Issue #4: `migrate.js` uses ES module imports and runs each SQL file inside an explicit `BEGIN`/`COMMIT` transaction, rolling back on any error. The migrations tracking table is bootstrapped with `CREATE TABLE IF NOT EXISTS` before querying it so the runner is idempotent on first use.
+
+## Constraints
+
+- Runtime: Node.js 20 (LTS) — no polyfills for natively available features.
+- Module system: ES Modules (`"type": "module"`) throughout; no CommonJS `require()`.
+- Database: PostgreSQL 15+ — use `gen_random_uuid()` (no `uuid-ossp` extension needed).
+- No ORM: All SQL is written explicitly; `pg` pool is the only database abstraction.
+- Authentication: Stateless JWT only; no server-side session store in MVP scope.
+- Password storage: `bcrypt` with configurable rounds (default 12).
+- Scope: REST API backend only; no frontend, no caching layer, no message broker in MVP.
+
+## Completed Issues
+
+- #4 — Write database migration for users table and migration runner

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "my-new-app",
+  "version": "1.0.0",
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "start": "node src/index.js",
+    "dev": "nodemon src/index.js",
+    "test": "jest",
+    "db:migrate": "node src/db/migrate.js"
+  },
+  "dependencies": {
+    "bcrypt": "^5.1.1",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2",
+    "morgan": "^1.10.0",
+    "pg": "^8.12.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "nodemon": "^3.1.4",
+    "supertest": "^7.0.0"
+  }
+}

--- a/src/db/migrate.js
+++ b/src/db/migrate.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Database migration runner.
+ *
+ * Reads all *.sql files from src/db/migrations/ in lexicographic order,
+ * skips files already recorded in the migrations table, and executes each
+ * remaining file inside a single transaction. On success the filename is
+ * recorded; on failure the transaction rolls back and the process exits
+ * with a non-zero code.
+ *
+ * Usage:
+ *   node src/db/migrate.js
+ */
+
+import { readdir, readFile } from 'node:fs/promises';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import pool from './pool.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = resolve(__dirname, 'migrations');
+
+async function run() {
+  // Read all .sql files in lexicographic order.
+  const entries = await readdir(MIGRATIONS_DIR);
+  const files = entries.filter((f) => f.endsWith('.sql')).sort();
+
+  if (files.length === 0) {
+    console.log('No migration files found.');
+    return;
+  }
+
+  // Ensure the migrations tracking table exists before querying it.
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS migrations (
+      id          SERIAL PRIMARY KEY,
+      filename    TEXT UNIQUE NOT NULL,
+      applied_at  TIMESTAMPTZ DEFAULT NOW()
+    )
+  `);
+
+  // Determine which migrations have already been applied.
+  const { rows } = await pool.query('SELECT filename FROM migrations');
+  const applied = new Set(rows.map((r) => r.filename));
+
+  const pending = files.filter((f) => !applied.has(f));
+
+  if (pending.length === 0) {
+    console.log('All migrations are already applied.');
+    return;
+  }
+
+  for (const filename of pending) {
+    const filePath = join(MIGRATIONS_DIR, filename);
+    const sql = await readFile(filePath, 'utf8');
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(sql);
+      await client.query(
+        'INSERT INTO migrations (filename) VALUES ($1)',
+        [filename],
+      );
+      await client.query('COMMIT');
+      console.log(`Applied: ${filename}`);
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw new Error(`Migration failed for ${filename}: ${err.message}`);
+    } finally {
+      client.release();
+    }
+  }
+}
+
+run()
+  .then(() => {
+    console.log('Migration complete.');
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err.message);
+    process.exit(1);
+  });

--- a/src/db/migrations/001_create_users.sql
+++ b/src/db/migrations/001_create_users.sql
@@ -1,0 +1,18 @@
+-- Migration: 001_create_users
+-- Creates the migrations tracking table and the users table.
+
+-- Tracking table: records which migrations have been applied.
+CREATE TABLE IF NOT EXISTS migrations (
+  id          SERIAL PRIMARY KEY,
+  filename    TEXT UNIQUE NOT NULL,
+  applied_at  TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Users table.
+CREATE TABLE users (
+  id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  email         TEXT        UNIQUE NOT NULL,
+  password_hash TEXT        NOT NULL,
+  created_at    TIMESTAMPTZ DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary

- Adds `src/db/migrations/001_create_users.sql` — creates the `migrations` tracking table (idempotent via `IF NOT EXISTS`) and the `users` table with `id` (UUID, `gen_random_uuid()`), `email` (unique, not null), `password_hash`, `created_at`, and `updated_at` columns.
- Adds `src/db/migrate.js` — reads `*.sql` files from `src/db/migrations/` in lexicographic order, skips already-applied filenames recorded in the `migrations` table, runs each pending file in a `BEGIN`/`COMMIT` transaction (rolling back on failure), and exits `0` on success or non-zero on error.
- Adds `package.json` with the `db:migrate` npm script (`node src/db/migrate.js`).
- Adds `PROJECT_STATE.md` recording issue #4 decisions and completed state.

Closes #4

## Test plan

- [ ] `npm run db:migrate` applies `001_create_users.sql` and logs `Applied: 001_create_users.sql`.
- [ ] Running `npm run db:migrate` a second time logs `All migrations are already applied.` and exits 0.
- [ ] Introducing a syntax error in a migration file causes the runner to roll back and exit non-zero.
- [ ] `users` table has the correct columns, types, constraints, and defaults in PostgreSQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)