### PR TITLE
feat(routes): implement GET /health liveness probe

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,0 +1,40 @@
+# Project State: my-new-app
+
+## Phase
+planning
+
+## Last Updated
+2026-02-28T19:56:00Z
+
+## Last Issue Processed
+#3 — Implement health check router
+
+## Decisions
+
+- Issue #7: `authService.js` uses named ES module exports; user objects strip `password_hash` via destructuring before returning to callers.
+- Issue #5: `errorHandler.js` uses `process.env.NODE_ENV` directly rather than importing `src/config.js`, since config does not expose a `nodeEnv` field; `err.status ?? err.statusCode ?? 500` handles both naming conventions.
+- Issue #3: `health.js` uses a default export for the Router; `new Date().toISOString()` provides the ISO 8601 timestamp at request time; no auth middleware applied.
+
+## Constraints
+
+- Runtime: Node.js 20 (LTS) — no polyfills for natively available features.
+- Module system: ES Modules (`"type": "module"`) throughout; no CommonJS `require()`.
+- Database: PostgreSQL 15+ — use `gen_random_uuid()` (no `uuid-ossp` extension needed).
+- No ORM: All SQL is written explicitly; `pg` pool is the only database abstraction.
+- Authentication: Stateless JWT only; no server-side session store in MVP scope.
+- Password storage: `bcrypt` with configurable rounds (default 12).
+- Scope: REST API backend only; no frontend, no caching layer, no message broker in MVP.
+
+## Completed Issues
+
+- #7 — Implement AuthService for password hashing and JWT operations
+- #5 — Implement centralized error handler middleware
+- #3 — Implement health check router
+
+## Next Recommended Issue
+
+**Issue 0** — "Initialize project scaffold with package.json and directory structure"
+
+This is the foundational prerequisite for all other issues. Start here by creating
+`package.json`, `.env.example`, `.gitignore`, and the `src/` directory tree as described
+in `ISSUES.json` index 0.

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/health', (req, res) => {
+  res.json({ status: 'ok', timestamp: new Date().toISOString() });
+});
+
+export default router;


### PR DESCRIPTION
## Summary

- Adds `src/routes/health.js` exporting an Express `Router`
- `GET /health` responds HTTP 200 with `{ status: 'ok', timestamp: <ISO 8601> }`
- No authentication required; pure liveness probe with no DB or external calls
- Imports only `express`; uses ES module default export

Closes #3

## Test plan

- [ ] `GET /health` returns HTTP 200
- [ ] Response body contains `status: 'ok'` and a valid ISO 8601 `timestamp`
- [ ] `Content-Type` header is `application/json`
- [ ] Route is accessible without an `Authorization` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)