### PR TITLE
feat: implement auth router with register and login endpoints (#9)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,0 +1,19 @@
+# Project State
+
+## Last Updated
+2026-02-28T00:00:00Z
+
+## Last Issue Processed
+#9 - Implement auth router with register and login endpoints
+
+## Completed Issues
+- #9
+
+## Decisions
+- Auth router (`src/routes/auth.js`) uses inline validation (no external validation library) per MVP constraints.
+- Error handling supports both thrown Error objects and thrown strings from AuthService for `'Email already registered'` and `'Invalid credentials'`.
+- All data access is delegated to `AuthService`; no direct repository or DB pool imports in the route layer.
+
+## Constraints
+- Import only `express` and `src/services/authService.js` in auth routes.
+- Input validation must be inline in route handlers (no additional validation library for MVP).

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,0 +1,50 @@
+const express = require('express');
+const AuthService = require('../services/authService');
+
+const router = express.Router();
+
+router.post('/register', async (req, res) => {
+  const { email, password } = req.body;
+
+  if (!email || typeof email !== 'string' || email.trim() === '') {
+    return res.status(400).json({ error: 'email is required' });
+  }
+  if (!password || typeof password !== 'string' || password.length < 8) {
+    return res.status(400).json({ error: 'password is required' });
+  }
+
+  try {
+    const user = await AuthService.register(email, password);
+    return res.status(201).json({ user: { id: user.id, email: user.email, created_at: user.created_at } });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : err;
+    if (message === 'Email already registered') {
+      return res.status(409).json({ error: 'Email already registered' });
+    }
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+router.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+
+  if (!email || typeof email !== 'string' || email.trim() === '') {
+    return res.status(400).json({ error: 'email is required' });
+  }
+  if (!password || typeof password !== 'string' || password.length < 8) {
+    return res.status(400).json({ error: 'password is required' });
+  }
+
+  try {
+    const result = await AuthService.login(email, password);
+    return res.status(200).json({ token: result.token, user: { id: result.user.id, email: result.user.email } });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : err;
+    if (message === 'Invalid credentials') {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- Adds `src/routes/auth.js` exporting an Express `Router` with two endpoints
- `POST /auth/register`: validates `{ email, password }`, calls `AuthService.register`, returns 201/400/409
- `POST /auth/login`: validates `{ email, password }`, calls `AuthService.login`, returns 200/400/401

## Details
- Inline input validation: `email` must be a non-empty string; `password` must be ≥ 8 characters — invalid fields return HTTP 400 `{ error: '<field> is required' }` before any service call
- Error handling covers both `Error` objects and thrown strings from `AuthService`
- No direct repository or DB pool imports — all data access delegated to `AuthService`
- No external validation library (MVP constraint)

## Test plan
- [ ] `POST /auth/register` with valid body → 201 `{ user: { id, email, created_at } }`
- [ ] `POST /auth/register` with duplicate email → 409 `{ error: 'Email already registered' }`
- [ ] `POST /auth/register` with missing/empty email → 400 `{ error: 'email is required' }`
- [ ] `POST /auth/register` with password < 8 chars → 400 `{ error: 'password is required' }`
- [ ] `POST /auth/login` with valid credentials → 200 `{ token, user: { id, email } }`
- [ ] `POST /auth/login` with wrong credentials → 401 `{ error: 'Invalid credentials' }`
- [ ] `POST /auth/login` with missing/empty email → 400 `{ error: 'email is required' }`
- [ ] `POST /auth/login` with password < 8 chars → 400 `{ error: 'password is required' }`
- [ ] All responses are `Content-Type: application/json`

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)