### PR TITLE
feat: assemble Express app and HTTP server entry point (#10)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,0 +1,40 @@
+# Project State: my-new-app
+
+## Phase
+planning
+
+## Last Updated
+2026-02-28T20:00:00Z
+
+## Last Issue Processed
+#10 — Assemble Express app and HTTP server entry point
+
+## Decisions
+
+- Issue #7: `authService.js` uses named ES module exports; user objects strip `password_hash` via destructuring before returning to callers.
+- Issue #5: `errorHandler.js` uses `process.env.NODE_ENV` directly rather than importing `src/config.js`, since config does not expose a `nodeEnv` field; `err.status ?? err.statusCode ?? 500` handles both naming conventions.
+- Issue #10: `src/app.js` exports the Express app without calling `listen`; `src/index.js` is the sole entry point that binds to a port, keeping the app importable by `supertest` without opening a socket.
+
+## Constraints
+
+- Runtime: Node.js 20 (LTS) — no polyfills for natively available features.
+- Module system: ES Modules (`"type": "module"`) throughout; no CommonJS `require()`.
+- Database: PostgreSQL 15+ — use `gen_random_uuid()` (no `uuid-ossp` extension needed).
+- No ORM: All SQL is written explicitly; `pg` pool is the only database abstraction.
+- Authentication: Stateless JWT only; no server-side session store in MVP scope.
+- Password storage: `bcrypt` with configurable rounds (default 12).
+- Scope: REST API backend only; no frontend, no caching layer, no message broker in MVP.
+
+## Completed Issues
+
+- #7 — Implement AuthService for password hashing and JWT operations
+- #5 — Implement centralized error handler middleware
+- #10 — Assemble Express app and HTTP server entry point
+
+## Next Recommended Issue
+
+**Issue 0** — "Initialize project scaffold with package.json and directory structure"
+
+This is the foundational prerequisite for all other issues. Start here by creating
+`package.json`, `.env.example`, `.gitignore`, and the `src/` directory tree as described
+in `ISSUES.json` index 0.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "my-new-app",
+  "version": "1.0.0",
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "start": "node src/index.js",
+    "dev": "nodemon src/index.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "bcrypt": "^5.1.1",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2",
+    "morgan": "^1.10.0",
+    "pg": "^8.12.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "nodemon": "^3.1.4",
+    "supertest": "^7.0.0"
+  }
+}

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,23 @@
+import express from 'express';
+import cors from 'cors';
+import morgan from 'morgan';
+
+import healthRouter from './routes/health.js';
+import authRouter from './routes/auth.js';
+import errorHandler from './middleware/errorHandler.js';
+
+const app = express();
+
+// Third-party middleware
+app.use(express.json());
+app.use(cors());
+app.use(morgan('dev'));
+
+// Routers
+app.use('/health', healthRouter);
+app.use('/auth', authRouter);
+
+// Error handler — must be registered after all routers
+app.use(errorHandler);
+
+export default app;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,6 @@
+import app from './app.js';
+import config from './config.js';
+
+app.listen(config.port, () => {
+  console.log(`Server listening on port ${config.port}`);
+});


### PR DESCRIPTION
## Summary

Closes #10

- **`src/app.js`**: Creates the Express application instance, applies `express.json()`, `cors()`, and `morgan('dev')` middleware in order, mounts `healthRouter` at `/health` and `authRouter` at `/auth`, registers `errorHandler` last. Does **not** call `app.listen` — safe to import in tests without opening a socket.
- **`src/index.js`**: The sole server entry point. Imports the app and `config`, calls `app.listen(config.port)`, and logs `Server listening on port <port>` to stdout.
- **`package.json`**: Adds `start` (`node src/index.js`) and `dev` (`nodemon src/index.js`) npm scripts alongside existing dependency declarations.

## Dependencies

This PR introduces the wiring layer and depends on the following issues being merged first:
- #1 (project scaffold / package.json baseline)
- #2 (`src/config.js`)
- #3 (`src/routes/health.js`)
- #5 (`src/middleware/errorHandler.js`)
- #9 (`src/routes/auth.js`)

## Test plan

- [ ] Verify `src/app.js` can be imported without side-effects (no listen, no DB connection at load time)
- [ ] Verify `node src/index.js` starts the server and logs `Server listening on port <port>` to stdout
- [ ] Verify `npm start` runs `node src/index.js`
- [ ] Verify `npm run dev` runs `nodemon src/index.js`
- [ ] Verify middleware order: `express.json` → `cors` → `morgan` → routers → `errorHandler`

🤖 Generated with [Claude Code](https://claude.com/claude-code)