### PR TITLE
feat: add users table migration and migration runner

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,18 +1,21 @@
 # Project State
 
 ## Last Updated
-2026-02-28T00:00:00Z
+2026-03-01T00:00:00Z
 
 ## Last Issue Processed
-#1 — Initialize project scaffold with package.json and directory structure
+#4 — Write database migration for users table and migration runner
 
 ## Completed Issues
 - #1
+- #4
 
 ## Decisions
 - Using ES Modules (`"type": "module"`) throughout; no CommonJS `require()`.
 - Node.js 20 only — no polyfills for features available natively in Node 20.
 - No ORM (Sequelize, Prisma, TypeORM, etc.) — raw `pg` for database access.
+- Migration runner uses `gen_random_uuid()` (PostgreSQL 13+); no `uuid-ossp` extension.
+- Each migration runs in a single transaction; failures roll back and are not recorded.
 
 ## Constraints
 - Node.js 20 engine required.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
-    "test": "jest"
+    "test": "jest",
+    "db:migrate": "node src/db/migrate.js"
   },
   "dependencies": {
     "bcrypt": "^5.1.1",

--- a/src/db/migrate.js
+++ b/src/db/migrate.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+import { readdir, readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import pool from './pool.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = join(__dirname, 'migrations');
+
+async function migrate() {
+  const client = await pool.connect();
+  try {
+    // Ensure migrations tracking table exists
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS migrations (
+        id SERIAL PRIMARY KEY,
+        filename TEXT UNIQUE NOT NULL,
+        applied_at TIMESTAMPTZ DEFAULT NOW()
+      )
+    `);
+
+    // Get already-applied migrations
+    const { rows: applied } = await client.query(
+      'SELECT filename FROM migrations'
+    );
+    const appliedSet = new Set(applied.map((r) => r.filename));
+
+    // Read all .sql files in lexicographic order
+    const files = (await readdir(MIGRATIONS_DIR))
+      .filter((f) => f.endsWith('.sql'))
+      .sort();
+
+    for (const file of files) {
+      if (appliedSet.has(file)) {
+        console.log(`Skipping already-applied migration: ${file}`);
+        continue;
+      }
+
+      const sql = await readFile(join(MIGRATIONS_DIR, file), 'utf8');
+
+      await client.query('BEGIN');
+      try {
+        await client.query(sql);
+        await client.query(
+          'INSERT INTO migrations (filename) VALUES ($1)',
+          [file]
+        );
+        await client.query('COMMIT');
+        console.log(`Applied migration: ${file}`);
+      } catch (err) {
+        await client.query('ROLLBACK');
+        throw new Error(`Migration ${file} failed and was rolled back: ${err.message}`);
+      }
+    }
+
+    console.log('All migrations complete.');
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+migrate().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/src/db/migrations/001_create_users.sql
+++ b/src/db/migrations/001_create_users.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS migrations (
+  id SERIAL PRIMARY KEY,
+  filename TEXT UNIQUE NOT NULL,
+  applied_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary

- Add `src/db/migrations/001_create_users.sql` with `migrations` tracking table and `users` table (`id` UUID PK with `gen_random_uuid()`, `email`, `password_hash`, `created_at`, `updated_at`)
- Add `src/db/migrate.js` migration runner: reads `*.sql` files lexicographically, skips already-applied files, executes each in a `BEGIN`/`COMMIT` transaction, rolls back on failure, exits 0 on success / non-zero on error
- Add `db:migrate` npm script to `package.json`
- Update `PROJECT_STATE.md` for issue #4

Closes #4

## Test plan

- [ ] Run `npm run db:migrate` against a local PostgreSQL instance and verify the `migrations` and `users` tables are created
- [ ] Run `npm run db:migrate` a second time and verify it logs "Skipping already-applied migration" without errors
- [ ] Introduce a syntax error in the SQL and verify the runner exits non-zero and does not record the filename

🤖 Generated with [Claude Code](https://claude.com/claude-code)