### PR TITLE
feat: assemble Express app and HTTP server entry point (#10)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,10 +1,10 @@
 # Project State
 
 ## Last Updated
-2026-03-01T00:00:00Z
+2026-03-01T01:00:00Z
 
 ## Last Issue Processed
-#9 — Implement auth router with register and login endpoints
+#10 — Assemble Express app and HTTP server entry point
 
 ## Completed Issues
 - #1
@@ -13,6 +13,7 @@
 - #7 — Implement AuthService for password hashing and JWT operations
 - #8 — Implement JWT authentication middleware
 - #9 — Implement auth router with register and login endpoints
+- #10 — Assemble Express app and HTTP server entry point
 
 ## Decisions
 - Using ES Modules (`"type": "module"`) throughout; no CommonJS `require()`.
@@ -25,6 +26,7 @@
 - Issue #7: `authService.js` uses named ES module exports; user objects strip `password_hash` via destructuring before returning to callers.
 - Issue #5: `errorHandler.js` uses `process.env.NODE_ENV` directly rather than importing `src/config.js`, since config does not expose a `nodeEnv` field; `err.status ?? err.statusCode ?? 500` handles both naming conventions.
 - Conflict resolution (#8 PR onto main): merged base branch state (through #9) with PR branch decisions for issues #5, #7, #8; preserved all decisions and augmented completed issues list.
+- Issue #10: `src/app.js` is side-effect-free at import time (no `listen`, no DB queries); `src/index.js` is the sole entry point that binds to a port. A minimal `/health` router was added at `src/routes/health.js` to satisfy the `/health` mount in `app.js`.
 
 ## Constraints
 - Node.js 20 engine required.

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,20 @@
+import express from 'express';
+import cors from 'cors';
+import morgan from 'morgan';
+
+import healthRouter from './routes/health.js';
+import authRouter from './routes/auth.js';
+import errorHandler from './middleware/errorHandler.js';
+
+const app = express();
+
+app.use(express.json());
+app.use(cors());
+app.use(morgan('dev'));
+
+app.use('/health', healthRouter);
+app.use('/auth', authRouter);
+
+app.use(errorHandler);
+
+export default app;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,6 @@
+import app from './app.js';
+import config from './config.js';
+
+app.listen(config.port, () => {
+  console.log(`Server listening on port ${config.port}`);
+});

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+export default router;


### PR DESCRIPTION
## Summary

- Adds `src/app.js`: wires `express.json()`, `cors()`, `morgan('dev')` middleware, mounts `/health` and `/auth` routers, and registers the error handler last
- Adds `src/routes/health.js`: minimal `GET /health` endpoint returning `{ status: 'ok' }`
- Adds `src/index.js`: sole entry point that binds the app to `config.port` and logs server start — no side-effects in `app.js` itself
- `package.json` `start`/`dev` scripts were already correctly set up; no changes needed

Closes #10

## Test plan

- [ ] `node src/index.js` starts the server and logs `Server listening on port 3000`
- [ ] `GET /health` returns `{ "status": "ok" }` with HTTP 200
- [ ] `src/app.js` can be imported by `supertest` without binding to a socket

🤖 Generated with [Claude Code](https://claude.com/claude-code)